### PR TITLE
zmodyfikowanie strony pod projekt haczyka

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -70,13 +70,45 @@
                     Warszawskiej
                   </p>
                 </a>
+                <a>
+                  <div class="haczyk_status">
+                    <div class="haczyk_left">
+                      <p class="haczyk_left_text">
+                        Warsztat 027
+                      </p>
+                    </div>
+                    <div class="haczyk_right haczyk_key_on">
+                    </div>   
+                  </div>                
+                </a>
+                <a>
+                  <div class="haczyk_status">
+                    <div class="haczyk_left">
+                      <p class="haczyk_left_text">
+                        Warsztat 028
+                      </p>
+                    </div>
+                    <div class="haczyk_right haczyk_key_off">
+                    </div>  
+                  </div>                
+                </a>
+                <a>
+                  <div class="haczyk_status">
+                    <div class="haczyk_left">
+                      <p class="haczyk_left_text">
+                        Warsztat 029
+                      </p>
+                    </div>
+                    <div class="haczyk_right haczyk_key_error" >
+                    </div>   
+                  </div>                
+                </a>
               </div>
             </div>
           </div>
         </div>
       </div>
     </footer>
-
     <script src="/js/aos.js"></script>
     <script
       type="text/javascript"

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1944,6 +1944,54 @@ div details ul {
     -webkit-transition:0.3s;
     transition:0.3s
 }
+/* Styl do haczyka na stronie głównej */
+.haczyk_status{
+    margin-bottom: 1rem;
+    display: flex;
+    cursor: pointer;
+}
+.haczyk_left {
+    position: relative;
+    width: 160px;
+    height: 40px;
+    margin: auto;
+    border-radius: 25px 0px 0px 25px;
+    background-color: #000000;
+    border-spacing: 0;
+}
+.haczyk_right {
+    position: relative;
+    width: 25px;
+    height: 40px;
+    margin: auto;
+    border-radius: 0px 25px 25px 0px;
+    border-spacing: 0;
+}
+.haczyk_key_on{
+    background-color: #008ae6;
+}
+.haczyk_key_off{
+    background-color: #424242;
+}
+.haczyk_key_error{
+    background-color: red;
+}
+.haczyk_left_text {
+    position: absolute;
+    height: 0%;
+    text-align: center;
+    top: 50%;
+    left: 25px;
+    width:80%;
+    font-weight: 700;
+    font-size: 19px;
+    line-height: 0;
+    margin: 0;
+    justify-content: center;
+    color: #ffffff;
+    white-space: nowrap;
+    user-select: none;
+}
 @media (max-width:767px){
     .footer__wrapper{
         -webkit-box-orient:vertical;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -70,6 +70,31 @@ function clickBars(navSelector, navItemsSelector, barsSelector){
     });
 }
 
+//Kod zmieniający tekst po najechaniu na stan haczyka wartatu
+const haczykStatusList = document.querySelectorAll('.haczyk_status');
+haczykStatusList.forEach(haczykStatus => {
+  const haczykLeftText = haczykStatus.querySelector('.haczyk_left_text');
+  const haczykRight = haczykStatus.querySelector('.haczyk_right');
+  const haczykOriginalText = haczykLeftText.textContent.trim();
+
+  function handleMouseEnter() {
+    if (haczykRight.classList.contains('haczyk_key_on')) {
+      haczykLeftText.textContent = 'Open';
+    }
+    if (haczykRight.classList.contains('haczyk_key_off')) {
+        haczykLeftText.textContent = 'Closed';
+      }
+    if (haczykRight.classList.contains('haczyk_key_error')) {
+        haczykLeftText.textContent = 'Error';
+    }
+  }
+  function handleMouseOut() {
+    haczykLeftText.textContent = haczykOriginalText;
+  }
+
+  haczykStatus.addEventListener('mouseover', handleMouseEnter);
+  haczykStatus.addEventListener('mouseout', handleMouseOut);
+});
 
 // document.addEventListener('DOMContentLoaded', function() {
 //     const dropdownToggle = document.querySelector('.dropdown-toggle');


### PR DESCRIPTION

![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/4351cb20-f07d-44bd-b1bb-623b986c0c72)


Stan jest zczytywany zależnie od tego jaka klasa jest przypisana do diva, aby zmiana jego wyglądu była jak najłatwiejsza
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/af9955dd-7a16-400c-8012-7bd2ecb9c952)

Tekst się zmienia na to co oznacza po najechaniu na status. Działa na urządzeniach mobilnych po kliknięciu
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/c1cfd94c-50f9-4f28-8e01-e3bb0ae3cbcd)
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/299c7c20-8b82-442b-83f6-e7f34afdfdcd)
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/e914e37a-7088-464a-b912-33946ea2117d)

Wcześniej zastanawiałem się nad białym kolorem ale trochę mi nie pasuje do tła footera, za mało się wyróżnia. Zamiast tego szarego można dać czarny.
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/08c90283-5d58-4ba2-a028-a8a541f8cf3f)
![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/b38733f6-8a59-4361-bac0-ed0a86d0fdfc)

Czerwony kolor nie musi do niczego pasować, ma się wyróżniać.
Kolor niebieski jest taki sam co w innych miejscach na stronie

![image](https://github.com/LukPogo/knr-pw.github.io/assets/54511421/49457795-20e5-4c50-ac4f-b0933ef20b69)

